### PR TITLE
Nic/dns

### DIFF
--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -355,7 +355,6 @@ Resources:
     Properties:
       SubnetId: !Ref PrivateSubnet3
       NetworkAclId: !Ref NetworkAcl
-    #DependsOn: PrivateSubnet3
 
   ElasticContainerRepository:
     Type: AWS::ECR::Repository

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -417,7 +417,6 @@ Resources:
               awslogs-stream-prefix: ecs
     DependsOn:
       - ElasticContainerServiceCluster
-      - Listener
       - LogGroup
 
   ECSExecutionRole:
@@ -464,8 +463,8 @@ Resources:
       VpcId: !Ref 'VPC'
       SecurityGroupIngress:
           - CidrIp: 0.0.0.0/0
-            FromPort: 80
-            ToPort: 80
+            FromPort: 443
+            ToPort: 443
             IpProtocol: "tcp"
 
   LoadBalancer:
@@ -500,12 +499,15 @@ Resources:
   Listener:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
+      Certificates: 
+        - CertificateArn: !Ref ACM
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref TargetGroup
       LoadBalancerArn: !Ref LoadBalancer
-      Port: 80
-      Protocol: HTTP
+      Port: 443
+      Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-FS-1-2-2019-08
 
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -528,3 +530,9 @@ Resources:
       HostedZoneId: !Ref DNS
       Name: ops-hire-project.cs1.nls.systems.
       Type: A
+
+  ACM:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: '*.cs1.nls.systems'
+      ValidationMethod: DNS

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -513,3 +513,19 @@ Resources:
     Properties:
       LogGroupName: !Join ['/', [/ecs, !Ref Name, !Ref Environment]]
       RetentionInDays: 3
+
+  DNS:
+    Type: AWS::Route53::HostedZone
+    Properties:
+      Name: cs1.nls.systems
+
+  ALBAlias:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt LoadBalancer.DNSName
+        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
+      Comment: friendly name on ALB
+      HostedZoneId: !Ref DNS
+      Name: ops-hire-project.cs1.nls.systems.
+      Type: A


### PR DESCRIPTION
Adding an alias of ops-hire-project.cs1.nls.systems on the ALB
Adding a wild card cert for *.cs1.nls.systems
Switching the listener and security group over to 443/SSL ('inside' leg of ALB is still HTTP/non ssl).

Got lost in down a rabbit hole of circular dependancies - the docs suggested I needed a AWS::ElasticLoadBalancingV2::ListenerCertificate resource for Listener.Certificates, when really it was just a ref to the ACM cert.