### PR TITLE
Nic/monitoring

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -24,7 +24,7 @@ def VariableSlowHelloWorld(param):
 @app.route("/oh_no")
 def fail():
     #abort(503)
-    abort(503, description="Well this is embarrasing...")
+    abort(503, description="Well this is embarrassing...")
 
 @app.route("/status")
 def status():

--- a/app/app.py
+++ b/app/app.py
@@ -7,31 +7,33 @@ from os import environ
 app = Flask(__name__)
 api = Api(app)
 
+APP_VERSION = "20.01.001"
+
 class HelloWorld(Resource):
     def get(self):
         return {'hello': 'world'}
 
-@app.route("/slow")
-def SlowHelloWorld():
-    sleep(1)
-    return {'slowello': 'world: 1'}
-
+# A 'slow' route that takes 1s to return, or if an int is supplied, will return in int many seconds
+# Simulates waiting on a request to another microservice
+@app.route("/slow", defaults={'param': 1})
 @app.route("/slow/<int:param>")
 def VariableSlowHelloWorld(param):
     sleep(param)
     return {'slowello': f'world: {param}'}
 
+# route that throws a 503 error, apps have been known to do this unintentionally from time to time
 @app.route("/oh_no")
 def fail():
-    #abort(503)
     abort(503, description="Well this is embarrassing...")
 
+# status route for ALB health checks, including debugging data from container
 @app.route("/status")
 def status():
     return {'status': 'OK',
             'hostname': environ['HOSTNAME'],
             'python': environ['PYTHON_VERSION'],
-            'region': environ['AWS_REGION']
+            'region': environ.get('AWS_REGION', 'non-aws'),
+            'app_version': APP_VERSION
             }
 
 api.add_resource(HelloWorld, '/')

--- a/app/app.py
+++ b/app/app.py
@@ -1,6 +1,8 @@
 # app.py - a minimal flask api using flask_restful
-from flask import Flask
+from flask import Flask, abort, Response
 from flask_restful import Resource, Api
+from time import sleep
+from os import environ
 
 app = Flask(__name__)
 api = Api(app)
@@ -8,6 +10,29 @@ api = Api(app)
 class HelloWorld(Resource):
     def get(self):
         return {'hello': 'world'}
+
+@app.route("/slow")
+def SlowHelloWorld():
+    sleep(1)
+    return {'slowello': 'world: 1'}
+
+@app.route("/slow/<int:param>")
+def VariableSlowHelloWorld(param):
+    sleep(param)
+    return {'slowello': f'world: {param}'}
+
+@app.route("/oh_no")
+def fail():
+    #abort(503)
+    abort(503, description="Well this is embarrasing...")
+
+@app.route("/status")
+def status():
+    return {'status': 'OK',
+            'hostname': environ['HOSTNAME'],
+            'python': environ['PYTHON_VERSION'],
+            'region': environ['AWS_REGION']
+            }
 
 api.add_resource(HelloWorld, '/')
 

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -654,7 +654,7 @@ Resources:
       Period: 900
       EvaluationPeriods: 1
       Threshold: 5
-      ComparisonOperator: LessThanThreshold
+      ComparisonOperator: GreaterThanThreshold
       AlarmActions:
         - !Ref SNSEmail
       InsufficientDataActions:

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -365,6 +365,9 @@ Resources:
     Type: AWS::ECS::Cluster
     Properties:
       ClusterName: !Join ['-', [!Ref Name, !Ref Environment]]
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
     DependsOn:
       - PrivateSubnet1
 
@@ -374,7 +377,7 @@ Resources:
       ServiceName: !Join ['', [!Ref Name, !Ref Environment]]
       Cluster: !Join ['-', [!Ref Name, !Ref Environment]]
       LaunchType: FARGATE
-      DesiredCount: 3
+      DesiredCount: 1
       NetworkConfiguration:
         AwsvpcConfiguration:
           Subnets:
@@ -547,7 +550,7 @@ Resources:
   SpendingAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: Alarm if AWS spending is over $3
+      AlarmDescription: Alarm if AWS spending is over $5
       Namespace: AWS/Billing
       MetricName: EstimatedCharges
       Dimensions:
@@ -556,9 +559,181 @@ Resources:
       Statistic: Maximum
       Period: 21600
       EvaluationPeriods: 1
-      Threshold: 3
+      Threshold: 5
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
-      - !Ref SNSEmail
+        - !Ref SNSEmail
       InsufficientDataActions:
-      - !Ref SNSEmail
+        - !Ref SNSEmail
+
+  LogAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm if incoming log events drops below 2
+      Namespace: AWS/Logs
+      MetricName: IncomingLogEvents
+      Dimensions:
+      - Name: LogGroupName
+        Value: /ecs/ops-hire-project/dev
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 2
+      ComparisonOperator: LessThanThreshold
+      AlarmActions:
+        - !Ref SNSEmail
+      InsufficientDataActions:
+        - !Ref SNSEmail
+
+  TaskCountAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm if number of tasks drops below 1
+      Namespace: ECS/ContainerInsights
+      MetricName: TaskCount
+      Dimensions:
+      - Name: ClusterName
+        Value: !Ref ElasticContainerServiceCluster
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 2
+      ComparisonOperator: LessThanThreshold
+      AlarmActions:
+        - !Ref SNSEmail
+      InsufficientDataActions:
+        - !Ref SNSEmail
+
+  ALBRequestsAnomalyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm if incoming requests spike
+      ComparisonOperator: LessThanLowerOrGreaterThanUpperThreshold
+      EvaluationPeriods: 1
+      Metrics:
+        - Expression: ANOMALY_DETECTION_BAND(m1, 2)
+          Id: ad1
+        - Id: m1
+          MetricStat:
+            Metric:
+              Dimensions:
+              - Name: LoadBalancer
+                Value: !GetAtt LoadBalancer.LoadBalancerFullName
+              MetricName: RequestCount
+              Namespace: AWS/ApplicationELB
+            Period: !!int 900
+            Stat: Sum
+            Unit: Count
+      ThresholdMetricId: ad1
+      AlarmActions:
+        - !Ref SNSEmail
+      InsufficientDataActions:
+        - !Ref SNSEmail
+
+  AnomalyDetectorOnALBRequests:
+    Type: AWS::CloudWatch::AnomalyDetector
+    Properties:
+      Dimensions:
+      - Name: LoadBalancer
+        Value: !GetAtt LoadBalancer.LoadBalancerFullName
+      Namespace: AWS/ApplicationELB
+      MetricName: RequestCount
+      Stat: Sum
+
+  ErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm if more than 5 503 errors are fired in an hour 
+      Namespace: AWS/ApplicationELB
+      MetricName: HTTPCode_Target_5XX_Count
+      Dimensions:
+      - Name: LoadBalancer
+        Value: !GetAtt LoadBalancer.LoadBalancerFullName
+      TreatMissingData: notBreaching
+      Statistic: Sum 
+      Period: 900
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: LessThanThreshold
+      AlarmActions:
+        - !Ref SNSEmail
+      InsufficientDataActions:
+        - !Ref SNSEmail
+
+  ECSCPUAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm if average ECS cpu load is over 50% 
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      Metrics:
+        - Expression: m1/m2*100
+          Id: e1
+          Label: CPUPercentage
+          ReturnData: true
+        - Id: m1
+          MetricStat:
+            Metric:
+              Dimensions:
+              - Name: ClusterName
+                Value: !Ref ElasticContainerServiceCluster
+              MetricName: CpuUtilized
+              Namespace: ECS/ContainerInsights
+            Period: 300 
+            Stat: Average
+          ReturnData: false
+        - Id: m2
+          MetricStat:
+            Metric:
+              Dimensions:
+              - Name: ClusterName
+                Value: !Ref ElasticContainerServiceCluster
+              MetricName: CpuReserved
+              Namespace: ECS/ContainerInsights
+            Period: 300 
+            Stat: Average
+          ReturnData: false
+      Threshold: 50
+      AlarmActions:
+        - !Ref SNSEmail
+      InsufficientDataActions:
+        - !Ref SNSEmail
+    
+  ECSMemAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm if average ECS memory load is over 75% 
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      Metrics:
+        - Expression: m1/m2*100
+          Id: e1
+          Label: MemPercentage
+          ReturnData: true
+        - Id: m1
+          MetricStat:
+            Metric:
+              Dimensions:
+              - Name: ClusterName
+                Value: !Ref ElasticContainerServiceCluster
+              MetricName: MemoryUtilized
+              Namespace: ECS/ContainerInsights
+            Period: 300 
+            Stat: Average
+          ReturnData: false
+        - Id: m2
+          MetricStat:
+            Metric:
+              Dimensions:
+              - Name: ClusterName
+                Value: !Ref ElasticContainerServiceCluster
+              MetricName: MemoryReserved
+              Namespace: ECS/ContainerInsights
+            Period: 300 
+            Stat: Average
+          ReturnData: false
+      Threshold: 75
+      AlarmActions:
+        - !Ref SNSEmail
+      InsufficientDataActions:
+        - !Ref SNSEmail

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -485,7 +485,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 120
-      HealthCheckPath: /
+      HealthCheckPath: /status
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -536,3 +536,29 @@ Resources:
     Properties:
       DomainName: '*.cs1.nls.systems'
       ValidationMethod: DNS
+
+  SNSEmail:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+      - Endpoint: "nicholaslscott+cs1@gmail.com"
+        Protocol: email
+  
+  SpendingAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm if AWS spending is over $3
+      Namespace: AWS/Billing
+      MetricName: EstimatedCharges
+      Dimensions:
+      - Name: Currency
+        Value: USD
+      Statistic: Maximum
+      Period: 21600
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+      - !Ref SNSEmail
+      InsufficientDataActions:
+      - !Ref SNSEmail

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -550,7 +550,7 @@ Resources:
   SpendingAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: Alarm if AWS spending is over $5
+      AlarmDescription: Alarm if AWS spending is over $10
       Namespace: AWS/Billing
       MetricName: EstimatedCharges
       Dimensions:
@@ -559,7 +559,7 @@ Resources:
       Statistic: Maximum
       Period: 21600
       EvaluationPeriods: 1
-      Threshold: 5
+      Threshold: 10
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
         - !Ref SNSEmail


### PR DESCRIPTION
Adding a slew of cloudwatch metrics. Tried to get a good mix - single metric, anomaly detection, and 'metric math' synthetic metrics.

Areas covered, billing/spend, number of containers running, application error rate, spikes in requests (not really 'actionable',  and would probably require tuning on how sensitive it is), and app cpu & memory usage.

Added some new routes to the app, '/slow' and '/slow/<int>' just to get some variability in response times (and for some load testing later). Also a route that throws a 503, again just to simulate something more interesting and exercise some of the ALB metrics. 