### PR TITLE
Nic/s3 file fetch

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -10,7 +10,8 @@ app = Flask(__name__)
 api = Api(app)
 
 APP_VERSION = "20.01.001"
-BUCKET_NAME = "ops-hire-project-nic-dev"
+# if running locally default to 'dev' environment
+BUCKET_NAME = environ.get('BUCKET_NAME', 'ops-hire-project-nic-dev')
 
 class HelloWorld(Resource):
     def get(self):

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -445,10 +445,14 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
             Action: 'sts:AssumeRole'
-      # ManagedPolicyArns:
-      #   -
-      # Policies:
-      #   -
+      Policies:
+        - PolicyName: !Sub '${Name}-${Environment}-s3_access'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: 'S3:GetObject'
+                Resource: !Sub 'arn:aws:s3:::${Name}-nic-${Environment}/*'
 
   ContainerSG:
     Type: AWS::EC2::SecurityGroup
@@ -737,3 +741,12 @@ Resources:
         - !Ref SNSEmail
       InsufficientDataActions:
         - !Ref SNSEmail
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub '${Name}-nic-${Environment}'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+    DeletionPolicy: Delete

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -406,6 +406,9 @@ Resources:
       ContainerDefinitions:
         - Name: !Ref Name
           Cpu: 256
+          Environment:
+            - Name: BUCKET_NAME
+              Value: !Ref S3Bucket
           Memory: 512
           # apparently you can't ref the ECR URI directly :(
           # format 028315980887.dkr.ecr.us-east-1.amazonaws.com/ops-hire-project-dev:latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 flask
 flask_restful
 gunicorn
+boto3
+botocore


### PR DESCRIPTION
Adding the s3 file fetch route.

If the file exists, returns it as a download. If the file does not exist, displays a 404.

Valid test files in https://ops-hire-project.cs1.nls.systems are:

https://ops-hire-project.cs1.nls.systems/fetch/cat.jpg
https://ops-hire-project.cs1.nls.systems/fetch/teapot.jpg
https://ops-hire-project.cs1.nls.systems/fetch/big/space.jpg

File never touches disk, so no IO nor file clean up to worry about (conversely if the file size is larger than available memory, it is probably going to break).