### PR TITLE
Nic/autoscale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY app/ app/
 WORKDIR /app
 
 CMD [ "gunicorn", \
+    "--workers=4", \
+    "--timeout=120", \
     "--access-logfile", "-", \
     "--bind", "0.0.0.0:8080", \
     "--access-logformat", "%({X-Forwarded-For}i)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\" %(L)s", \

--- a/app/app.py
+++ b/app/app.py
@@ -1,7 +1,6 @@
 # app.py - a minimal flask api using flask_restful
 from flask import Flask, abort, Response, send_file
 from flask_restful import Resource, Api
-from time import sleep
 from os import environ
 import boto3
 import botocore
@@ -13,17 +12,23 @@ APP_VERSION = "20.01.001"
 # if running locally default to 'dev' environment
 BUCKET_NAME = environ.get('BUCKET_NAME', 'ops-hire-project-nic-dev')
 
+def fib(n):
+    if n < 2:
+        return 1
+    else:
+        return fib(n - 1) + fib(n - 2)
+
 class HelloWorld(Resource):
     def get(self):
         return {'hello': 'world'}
 
-# A 'slow' route that takes 1s to return, or if an int is supplied, will return in int many seconds
+# A 'slow' route that takes a parameter and calculates the Fibonacci number
 # Simulates waiting on a request to another microservice
 @app.route("/slow/", defaults={'param': 1})
 @app.route("/slow/<int:param>")
 def VariableSlowHelloWorld(param):
-    sleep(param)
-    return {'slowello': f'world: {param}'}
+    f = fib(param)
+    return {'slowello': f'world: {f}'}
 
 # route that throws a 503 error, apps have been known to do this unintentionally from time to time
 @app.route("/oh_no")
@@ -40,7 +45,7 @@ def status():
             'app_version': APP_VERSION
             }
 
-# downloads a files from s3 (will work with sub folders as well) and pipes it back as an attachement/download.
+# downloads a files from s3 (will work with sub folders as well) and pipes it back as an attachment/download.
 @app.route("/fetch/<path:file_name>")
 def fetch(file_name):
     client = boto3.client('s3')

--- a/infrastructure/infrastructure.yml
+++ b/infrastructure/infrastructure.yml
@@ -771,3 +771,39 @@ Resources:
       ServiceName: !Sub com.amazonaws.${AWS::Region}.ecr.dkr
       VpcEndpointType: Interface
       VpcId: !Ref VPC
+
+  AutoScalingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${Name}-nic-${Environment}'
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole'
+
+  AutoScalingTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MinCapacity: 2
+      MaxCapacity: 6
+      ResourceId: !Join ['/', [service, !Ref ElasticContainerServiceCluster, !GetAtt ElasticContainerService.Name]]
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      RoleARN: !GetAtt AutoScalingRole.Arn
+
+  AutoScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: !Sub '${Name}-${Environment}'
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref AutoScalingTarget
+      TargetTrackingScalingPolicyConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ECSServiceAverageCPUUtilization
+        ScaleInCooldown: 120
+        ScaleOutCooldown: 120
+        TargetValue: 50

--- a/locust/Dockerfile
+++ b/locust/Dockerfile
@@ -1,0 +1,3 @@
+FROM locustio/locust
+
+ADD locustfile.py locustfile.py

--- a/locust/README.md
+++ b/locust/README.md
@@ -2,7 +2,7 @@
 
 ## Quickstart
 
-build the container ```docker build . -t locust``` and run it  ```docker run -p 8089:8089 -e TARGET_URL=https://ops-hire-project.cs1.nls.systems locust:latest``` connect to localhost:8089, and set the number of workers (21 is just enough to trip the cpu load and cause autoscaling to kicking in) and spawn rate (doesn't really matter, 0.25 is nice and slow)
+build the container ```docker build . -t locust``` and run it with ```docker run -p 8089:8089 -e TARGET_URL=https://ops-hire-project.cs1.nls.systems locust:latest``` connect to localhost:8089, and set the number of workers (21 is just enough to trip the cpu based autoscale group to kick in) and spawn rate (doesn't really matter, 0.25 is nice and slow)
 
 This basic test will fire one request per worker, every second (regardless of response time), hitting /, /status and /slow/25 33% of the time each. "/slow/25" taking hundreds of milliseconds to run, the others single digit milliseconds.
 

--- a/locust/README.md
+++ b/locust/README.md
@@ -1,0 +1,8 @@
+# Locust.io load tester
+
+## Quickstart
+
+build the container ```docker build . -t locust``` and run it  ```docker run -p 8089:8089 -e TARGET_URL=https://ops-hire-project.cs1.nls.systems locust:latest``` connect to localhost:8089, and set the number of workers (21 is just enough to trip the cpu load and cause autoscaling to kicking in) and spawn rate (doesn't really matter, 0.25 is nice and slow)
+
+This basic test will fire one request per worker, every second (regardless of response time), hitting /, /status and /slow/25 33% of the time each. "/slow/25" taking hundreds of milliseconds to run, the others single digit milliseconds.
+

--- a/locust/locustfile.py
+++ b/locust/locustfile.py
@@ -1,0 +1,22 @@
+# https://github.com/locustio/locust/blob/master/examples/basic.py
+from locust import HttpLocust, TaskSet, task, between, constant_pacing
+
+def index(l):
+    l.client.get("/")
+
+def status(l):
+    l.client.get("/status")
+
+def slow(l):
+    l.client.get("/slow/25")
+
+class UserTasks(TaskSet):
+    # one can specify tasks like this
+    tasks = [index, status, slow]
+
+class WebsiteUser(HttpLocust):
+    """
+    Locust user class that does requests to the locust web server running on localhost
+    """
+    wait_time = constant_pacing(1)
+    task_set = UserTasks


### PR DESCRIPTION
Adding target tracking autoscale to ecs service.

Autoscale will attempt to keep services average cpu load at 50% (if it goes over for 3 minutes, it will spin up an extra task, conversely if under 50% average cpu for 15 minutes, it will spin down a task).

Boosted concurrency in the container, to handle the mix of fast and slow requests, to allow the container to server up things like the /status url while also churning away on /slow/<N> requests.